### PR TITLE
set cache-control headers in expires.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 
 # Overwrite default config
 COPY nginx-site.conf /etc/nginx/conf.d/default.conf
+COPY expires.conf /etc/nginx/conf.d/expires.conf
 
 # Set a path to config file to be written, can be changed at runtime
 ENV CONFIG_FILE_PATH /app

--- a/expires.conf
+++ b/expires.conf
@@ -1,0 +1,8 @@
+# Expires map
+map $sent_http_content_type $expires {
+    default                    off;
+    text/html                  epoch;
+    text/css                   epoch;
+    application/javascript     epoch;
+    ~image/                    12h;
+}

--- a/expires.conf
+++ b/expires.conf
@@ -4,5 +4,6 @@ map $sent_http_content_type $expires {
     text/html                  epoch;
     text/css                   epoch;
     application/javascript     epoch;
+    application/json           epoch;
     ~image/                    12h;
 }

--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -33,6 +33,7 @@ server {
   server_name localhost;
   root /app;
 
+  expires $expires;
 
   # To make sure any assets can get through :)
   location / {


### PR DESCRIPTION
set cache-control headers in expires.conf where they can be easily overwritten by derivative images

This change addresses issue #4 